### PR TITLE
Fix `get_cell` for augmented version of PyDict

### DIFF
--- a/tvm-python/PyDict.cpp
+++ b/tvm-python/PyDict.cpp
@@ -99,6 +99,10 @@ bool PyAugmentationCheckData::eval_empty(vm::CellBuilder& cb) const {
 }
 
 PyCell PyDict::get_pycell() const {
+  if (is_augmented) {
+    auto dict = static_cast<vm::AugmentedDictionary*>(my_dict.get());
+    return PyCell(dict->get_root()->get_base_cell());
+  }
   td::Ref<vm::Cell> root = my_dict->get_root_cell();
   return PyCell(root);
 }


### PR DESCRIPTION
Since we need to store extra data in root node for augmented dictionary, we should call `AugmentedDictionary::get_root()` method for augmented PyDict to produce correct root cell. Otherwise, `VmDict.get_cell()` method produces invalid `HashmapAugE` cell.